### PR TITLE
Outra condição para describe

### DIFF
--- a/R/describe.R
+++ b/R/describe.R
@@ -12,110 +12,104 @@
 #'
 #' @return Prints to console. Invisibly returns NULL.
 #' @export
-describe <- function(x) {
+describe <- function (x)
+{
   clean_str <- function(val) {
-    if (is.null(val) || (length(val) == 1 && is.na(val))) return(NULL)
+    if (is.null(val) || (length(val) == 1 && is.na(val)))
+      return(NULL)
     gsub("\\\\\"", "\"", paste(val, collapse = ", "))
   }
-
   if (tibble::is_tibble(x)) {
-    # -------- DATASET --------
-    attrs <- list(
-      path           = attr(x, "path", exact = TRUE),
-      name           = attr(x, "name", exact = TRUE),
-      label          = attr(x, "label", exact = TRUE),
-      class          = attr(x, "dataset_class", exact = TRUE),
-      subclass       = attr(x, "dataset_subclass", exact = TRUE),
-      structure      = attr(x, "dataset_structure", exact = TRUE),
-      key_variables  = attr(x, "key_variables", exact = TRUE),
-      standard       = attr(x, "standard", exact = TRUE),
-      has_no_data    = attr(x, "has_no_data", exact = TRUE),
-      repeating      = attr(x, "repeating", exact = TRUE),
-      reference_data = attr(x, "reference_data", exact = TRUE),
-      comment        = attr(x, "comment", exact = TRUE)
-    )
-
+    attrs <- list(path = attr(x, "path", exact = TRUE),
+                  name = attr(x, "name", exact = TRUE), label = attr(x,
+                                                                     "label", exact = TRUE), class = attr(x, "dataset_class",
+                                                                                                          exact = TRUE), subclass = attr(x, "dataset_subclass",
+                                                                                                                                         exact = TRUE), structure = attr(x, "dataset_structure",
+                                                                                                                                                                         exact = TRUE), key_variables = attr(x, "key_variables",
+                                                                                                                                                                                                             exact = TRUE), standard = attr(x, "standard",
+                                                                                                                                                                                                                                            exact = TRUE), has_no_data = attr(x, "has_no_data",
+                                                                                                                                                                                                                                                                              exact = TRUE), repeating = attr(x, "repeating",
+                                                                                                                                                                                                                                                                                                              exact = TRUE), reference_data = attr(x, "reference_data",
+                                                                                                                                                                                                                                                                                                                                                   exact = TRUE), comment = attr(x, "comment",
+                                                                                                                                                                                                                                                                                                                                                                                 exact = TRUE))
     cli::cli_h1("📊 Dataset Description")
-
-    # Identificação
     cli::cli_h2("Basic information")
-    for (nm in c("path", "name", "label", "class", "subclass", "structure", "repeating", "key_variables", "standard", "has_no_data", "reference_data", "comment")) {
+    for (nm in c("path", "name", "label", "class", "subclass",
+                 "structure", "repeating", "key_variables", "standard",
+                 "has_no_data", "reference_data", "comment")) {
       val <- clean_str(attrs[[nm]])
-      if (!is.null(val)) cli::cli_li(paste0("{.field ", nm, "}: ", val))
+      if (!is.null(val))
+        cli::cli_li(paste0("{.field ", nm, "}: ", val))
     }
-
     invisible(NULL)
-
-  } else {
-    # -------- COLUMN --------
+  }
+  else {
     nm <- deparse(substitute(x))
-
-    attrs <- list(
-      order       = attr(x, "order", exact = TRUE),
-      dataset     = attr(x, "dataset", exact = TRUE),
-      variable    = attr(x, "variable", exact = TRUE),
-      label       = attr(x, "label", exact = TRUE),
-      data_type   = attr(x, "data_type", exact = TRUE),
-      length      = attr(x, "length", exact = TRUE),
-      signif_dig  = attr(x, "significant_digits", exact = TRUE),
-      format      = attr(x, "format", exact = TRUE),
-      mandatory   = attr(x, "mandatory", exact = TRUE),
-      closed      = attr(x, "closed", exact = TRUE),
-      codelist    = attr(x, "codelist", exact = TRUE),
-      origin      = attr(x, "origin", exact = TRUE),
-      source      = attr(x, "source", exact = TRUE),
-      predecessor = attr(x, "predecessor", exact = TRUE),
-      has_no_data = attr(x, "has_no_data", exact = TRUE),
-      comment     = attr(x, "comment", exact = TRUE)
-    )
-
-    method_attrs <- list(
-      name        = attr(x, "method_name", exact = TRUE),
-      type        = attr(x, "method_type", exact = TRUE),
-      description = attr(x, "method_description", exact = TRUE),
-      context     = attr(x, "method_expression_context", exact = TRUE),
-      code        = attr(x, "method_expression_code", exact = TRUE)
-    )
-
-    valuelevel_attrs <- list(
-      where_clause = attr(x, "valuelevel_where_clause", exact = TRUE),
-      codelist     = attr(x, "valuelevel_codelist", exact = TRUE),
-      origin       = attr(x, "valuelevel_origin", exact = TRUE),
-      source       = attr(x, "valuelevel_source", exact = TRUE),
-      predecessor  = attr(x, "valuelevel_predecessor", exact = TRUE),
-      method_id    = attr(x, "valuelevel_method_id", exact = TRUE),
-      comment_id   = attr(x, "valuelevel_comment_id", exact = TRUE)
-    )
-
+    attrs <- list(order = attr(x, "order", exact = TRUE),
+                  dataset = attr(x, "dataset", exact = TRUE), variable = attr(x,
+                                                                              "variable", exact = TRUE), label = attr(x, "label",
+                                                                                                                      exact = TRUE), data_type = attr(x, "data_type",
+                                                                                                                                                      exact = TRUE), length = attr(x, "length", exact = TRUE),
+                  signif_dig = attr(x, "significant_digits", exact = TRUE),
+                  format = attr(x, "format", exact = TRUE), mandatory = attr(x,
+                                                                             "mandatory", exact = TRUE), closed = attr(x,
+                                                                                                                       "closed", exact = TRUE), codelist = attr(x,
+                                                                                                                                                                "codelist", exact = TRUE), origin = attr(x,
+                                                                                                                                                                                                         "origin", exact = TRUE), source = attr(x, "source",
+                                                                                                                                                                                                                                                exact = TRUE), predecessor = attr(x, "predecessor",
+                                                                                                                                                                                                                                                                                  exact = TRUE), has_no_data = attr(x, "has_no_data",
+                                                                                                                                                                                                                                                                                                                    exact = TRUE), comment = attr(x, "comment",
+                                                                                                                                                                                                                                                                                                                                                  exact = TRUE))
+    method_attrs <- list(name = attr(x, "method_name", exact = TRUE),
+                         type = attr(x, "method_type", exact = TRUE), description = attr(x,
+                                                                                         "method_description", exact = TRUE), context = attr(x,
+                                                                                                                                             "method_expression_context", exact = TRUE),
+                         code = attr(x, "method_expression_code", exact = TRUE))
+    valuelevel_attrs <- list(where_clause = attr(x, "valuelevel_where_clause",
+                                                 exact = TRUE), codelist = attr(x, "valuelevel_codelist",
+                                                                                exact = TRUE), origin = attr(x, "valuelevel_origin",
+                                                                                                             exact = TRUE), source = attr(x, "valuelevel_source",
+                                                                                                                                          exact = TRUE), predecessor = attr(x, "valuelevel_predecessor",
+                                                                                                                                                                            exact = TRUE), method_id = attr(x, "valuelevel_method_id",
+                                                                                                                                                                                                            exact = TRUE), comment_id = attr(x, "valuelevel_comment_id",
+                                                                                                                                                                                                                                             exact = TRUE))
     cli::cli_h1("🔹 Column Description")
-
-    # Identificação
     cli::cli_h2("Basic information")
-    for (nm in c("order", "dataset", "variable", "label", "data_type", "length", "signif_dig", "format", "mandatory", "closed", "codelist", "origin", "source", "predecessor", "has_no_data", "comment")) {
+    for (nm in c("order", "dataset", "variable", "label",
+                 "data_type", "length", "signif_dig", "format", "mandatory",
+                 "closed", "codelist", "origin", "source", "predecessor",
+                 "has_no_data", "comment")) {
       val <- clean_str(attrs[[nm]])
-      if (!is.null(val)) cli::cli_li(paste0("{.field ", nm, "}: ", val))
+      if (!is.null(val))
+        cli::cli_li(paste0("{.field ", nm, "}: ", val))
     }
-
-    # Value Level
     if (!all(sapply(valuelevel_attrs, is.na))) {
       cli::cli_h2("Value Level information")
       for (nm in names(valuelevel_attrs)) {
         val <- clean_str(valuelevel_attrs[[nm]])
-        if (!is.null(val)) cli::cli_li(paste0("{.field ", nm, "}: ", val))
+        if (!is.null(val))
+          cli::cli_li(paste0("{.field ", nm, "}: ",
+                             val))
       }
-
       cli::cli_alert_info("Value-level metadata available. Check spec.xlsx or define.xml for more information.")
     }
-
-    # Method
     if (!all(sapply(method_attrs, is.na))) {
       cli::cli_h2("Method information")
       for (nm in names(method_attrs)) {
         val <- clean_str(method_attrs[[nm]])
-        if (!is.null(val)) cli::cli_li(paste0("{.field ", nm, "}: ", val))
+        if (!is.null(val)){
+
+          if(stringr::str_sub(val, 1, 2) == "If"){
+            cli::cli_li(paste0("{.field ", nm, "}: "))
+            cat(val)}
+
+          if(stringr::str_sub(val, 1, 2) != "If"){
+            cli::cli_li(paste0("{.field ", nm, "}: ",
+                               val))}
+
+        }
       }
     }
-
     invisible(NULL)
   }
 }

--- a/R/describe.R
+++ b/R/describe.R
@@ -99,11 +99,12 @@ describe <- function (x)
         val <- clean_str(method_attrs[[nm]])
         if (!is.null(val)){
 
-          if(stringr::str_sub(val, 1, 2) == "If"){
+
+          if(nm == "description"){
             cli::cli_li(paste0("{.field ", nm, "}: "))
             cat(val)}
 
-          if(stringr::str_sub(val, 1, 2) != "If"){
+          if(nm != "description"){
             cli::cli_li(paste0("{.field ", nm, "}: ",
                                val))}
 

--- a/R/method_numcat.R
+++ b/R/method_numcat.R
@@ -1,0 +1,17 @@
+mtnumcat <- function(dataset){
+  j <- 1
+  for(i in colnames(dataset)){
+    #if(attr(dataset[[i]], "method_name") == "Algorithm to derive numeric code from categorical variable"){
+    if(stringr::str_sub(attr(dataset[[i]], "label"), -4, -1) == " (N)"){
+      dataset <- dataset |>
+        derive2(var_target = !!colnames(dataset)[j],
+                var_source = !!colnames(dataset)[j-1],
+                by = rlang::exprs(USUBJID))
+    }
+
+    j <- j + 1
+  }
+  return(dataset)
+}
+
+vaicorinthia <- mtnumcat(adsl)


### PR DESCRIPTION
Na versão anterior, ele printa respeitando a formatação só quando a descrição do método começa com "If", mas percebi que isso nem sempre vai ser verdade, então atualizei. Agora qualquer texto que seja referente ao description do method vai ser impresso formatado

PS: não cheguei a comentar, mas precisa dessa condição porque sem ela se perde a quebra de linha que tem dentro de method entre "name", "type" e o "description"
